### PR TITLE
修复客户端状态切换参数错误

### DIFF
--- a/apps/web-antd/src/views/system/client/index.vue
+++ b/apps/web-antd/src/views/system/client/index.vue
@@ -122,7 +122,7 @@ async function handleChangeStatus(
   row: Client,
 ) {
   await clientChangeStatus({
-    clientId: row.id,
+    clientId: row.clientId,
     status: checked ? EnableStatus.Enable : EnableStatus.Disable,
   });
 }


### PR DESCRIPTION
客户端状态切换接口需要传递 `clientId`，但页面中原来传递的是 `row.id`，导致状态切换请求参数不正确。

本次调整为使用 `row.clientId`，与客户端模型和接口参数保持一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了客户端状态切换时提交标识错误的问题，启用/禁用操作现在会作用于正确的客户端记录。
  * 状态切换后的交互逻辑保持不变，用户体验更稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->